### PR TITLE
Fix missing protoc-gen-go-grpc binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,12 @@ RUN cmake ../..  \
 RUN make
 RUN make install
 
+# Workaround for the transition to protoc-gen-go-grpc
+# https://grpc.io/docs/languages/go/quickstart/#regenerate-grpc-code
+WORKDIR /tmp
+RUN git clone -b v$grpc.x --recursive https://github.com/grpc/grpc-go.git
+RUN ( cd ./grpc-go/cmd/protoc-gen-go-grpc && go install . )
+
 WORKDIR /tmp
 RUN git clone -b v$grpc_java.x --recursive https://github.com/grpc/grpc-java.git
 WORKDIR /tmp/grpc-java/compiler


### PR DESCRIPTION
As part of the transition from the old protobuf 1.3 to the new protobuf 1.4, the binary required to generate gRPC parts has moved into the grpc-go repo. This is process is currently underway so this PR uses the interim workaround defined in https://grpc.io/docs/languages/go/quickstart/#regenerate-grpc-code