### PR TITLE
Add support for BigQuery schema generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+.vscode/
 .DS_STORE
 test.pb.go
 test.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ WORKDIR /tmp
 # Omniproto
 RUN go get -u github.com/grpckit/omniproto
 
+RUN go get -u github.com/GoogleCloudPlatform/protoc-gen-bq-schema
+
 # Add Ruby Sorbet types support (rbi)
 RUN go get -u github.com/coinbase/protoc-gen-rbi
 


### PR DESCRIPTION
As it says, add `bq-schema` to the list of generators this supports.

This allows us to use this from omniproto like so:

```yaml
rootdir: .
sources:
  - sample_table.proto
output: gen
plugins:
  - name: go
    args: paths=source_relative
  - name: validate
    args: paths=source_relative,lang=go
  - name: bq-schema # <-- Use `bq-schema` for the generator
    args: paths=source_relative
debug: true
descriptors:
  enabled: false
```

```proto
syntax = "proto3";
package my_table;
option go_package = "github.com/grpckit/grpckit/my_table";
import "google/protobuf/timestamp.proto";
import "google/gen_bq_schema/bq_table.proto";

// SampleTable - This is what we write to BigQuery
message SampleTable {
  option (gen_bq_schema.bigquery_opts).table_name = "sample_table";

  google.protobuf.Timestamp timestamp = 1;  // Timestamp of this event
  bytes                                       data = 2;  // Raw bytes of the input

  // ... more fields here
}

```