### PR TITLE
Install protoc-gen-go-vtproto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ RUN go install github.com/GoogleCloudPlatform/protoc-gen-bq-schema@latest
 # Add Ruby Sorbet types support (rbi)
 RUN go install github.com/coinbase/protoc-gen-rbi@latest
 
+# vtproto
+RUN go install github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@latest
+
 FROM build-go AS build
 ARG grpc
 ARG grpc_java

--- a/Earthfile
+++ b/Earthfile
@@ -162,6 +162,9 @@ protobuf-go:
   # Add Ruby Sorbet types support (rbi)
   RUN go install github.com/coinbase/protoc-gen-rbi@latest
 
+  # vtproto
+  RUN go install github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@latest
+
   SAVE ARTIFACT /go/bin /go/bin
 
 grpckit-build:


### PR DESCRIPTION
# Summary

This gives us the ability to squeeze performance out of proto. `protoc-gen-gogo` is long deprecated since the SDK upgrade to v2.

Repo: https://github.com/planetscale/vtprotobuf
Blog: https://vitess.io/blog/2021-06-03-a-new-protobuf-generator-for-go/

# Test Plan

`make build`:
<img width="1446" alt="image" src="https://github.com/grpckit/grpckit/assets/8285973/29206b18-f64d-4709-a2d6-248ceb755bd4">
